### PR TITLE
GOOGLEDOCS-316 : Improve check-in error message for titles containing…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ atlassian-ide-plugin.xml
 
 Google Docs Share/src/main/amp/config/alfresco/web-extension/custom-slingshot-googledocs-context.xml
 Google Docs Repository/src/main/oauth-client-resources/**
+Google Docs Repository/src/main/amp/config/alfresco/subsystems/googledocs/drive/google-customResponse-context.xml

--- a/Google Docs Share/src/main/amp/config/alfresco/messages/googledocs_en.properties
+++ b/Google Docs Share/src/main/amp/config/alfresco/messages/googledocs_en.properties
@@ -60,7 +60,7 @@ googledocs.concurrentEditors.text=Other users are editing this document. Changes
 
 # Invalid Filename
 googledocs.invalidFilename.title=Invalid Filename
-googledocs.invalidFilename.text=File can't be saved. Try using different characters.
+googledocs.invalidFilename.text=Document cannot be saved to Alfresco. The filename contains illegal characters. A filename cannot contain any of the following characters: * " < > \ / ? : |.
 
 # Access Denied
 googledocs.accessDenied.title=Access Denied


### PR DESCRIPTION
… illegal characters

   - Updated googledocs_en.properties properties file;
   - Updated .gitignore.