### PR TITLE
Googledocs 418

### DIFF
--- a/Google Docs Repository/pom.xml
+++ b/Google Docs Repository/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>org.alfresco.integrations</groupId>
         <artifactId>alfresco-GoogleDocs</artifactId>
-        <version>3.1.0-RC2</version>
+        <version>3.1.0-RC2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/Google Docs Repository/pom.xml
+++ b/Google Docs Repository/pom.xml
@@ -14,8 +14,8 @@
 
     <properties>
         <org.springframework.social-google-version>1.0.0.RELEASE</org.springframework.social-google-version>
-        <alfresco-community.version>6.37</alfresco-community.version>
-        <alfresco-enterprise.version>6.37</alfresco-enterprise.version>
+        <alfresco-community.version>6.38</alfresco-community.version>
+        <alfresco-enterprise.version>6.38</alfresco-enterprise.version>
     </properties>
 
     <dependencies>

--- a/Google Docs Share/pom.xml
+++ b/Google Docs Share/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.alfresco.integrations</groupId>
         <artifactId>alfresco-GoogleDocs</artifactId>
-        <version>3.1.0-RC2</version>
+        <version>3.1.0-RC2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/Google Docs Share/pom.xml
+++ b/Google Docs Share/pom.xml
@@ -7,9 +7,8 @@
     <name>Alfresco / Google Docs Share Module</name>
 
     <properties>
-        <!--TODO: replace 6.0.0-SNAPSHOT with RC when available-->
-        <alfresco-community.version>6.0.0-SNAPSHOT</alfresco-community.version>
-        <alfresco-enterprise.version>6.0.0-SNAPSHOT</alfresco-enterprise.version>
+        <alfresco-community.version>6.0.a</alfresco-community.version>
+        <alfresco-enterprise.version>6.0.a</alfresco-enterprise.version>
     </properties>
 
     <parent>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.alfresco.integrations</groupId>
    <artifactId>alfresco-GoogleDocs</artifactId>
-   <version>3.1.0-RC2</version>
+   <version>3.1.0-RC2-SNAPSHOT</version>
    <name>alfresco-GoogleDocs</name>
    <packaging>pom</packaging>
 


### PR DESCRIPTION
- update 'alfresco-repository' and 'share' version to match the ones in 'acs-community-packaging'
- update googledrive module versions;