### PR TITLE
GOOGLEDOCS-434 : Build: Update GoogleDocs artefact naming for 3.1.0 RC2

### DIFF
--- a/googledrive-repository/pom.xml
+++ b/googledrive-repository/pom.xml
@@ -63,7 +63,7 @@
     </dependencies>
 
     <build>
-        <finalName>${project.artifactId}-${project.version}-${buildnumber}</finalName>
+        <finalName>${project.artifactId}${alfresco.google.config.classifier}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -119,15 +119,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.alfresco.maven.plugin</groupId>
-                <artifactId>alfresco-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <classifier>6.0</classifier>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -136,7 +127,7 @@
             <id>enterprise</id>
             <properties>
                 <alfresco.version>${alfresco-enterprise.version}</alfresco.version>
-                <alfresco.google.config.classifier>enterprise</alfresco.google.config.classifier>
+                <alfresco.google.config.classifier></alfresco.google.config.classifier>
             </properties>
             <dependencies>
                 <dependency>

--- a/googledrive-share/pom.xml
+++ b/googledrive-share/pom.xml
@@ -45,7 +45,7 @@
     </dependencies>
 
     <build>
-        <finalName>${project.artifactId}-${project.version}-${buildnumber}</finalName>
+        <finalName>${project.artifactId}${alfresco.google.config.classifier}-${project.version}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -109,15 +109,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.alfresco.maven.plugin</groupId>
-                <artifactId>alfresco-maven-plugin</artifactId>
-                <version>2.0.0</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <classifier>6.0</classifier>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -126,6 +117,7 @@
             <id>enterprise</id>
             <properties>
                 <alfresco.version>${alfresco-enterprise.version}</alfresco.version>
+                <alfresco.google.config.classifier></alfresco.google.config.classifier>
             </properties>
         </profile>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
       <alfresco.min.version>6.0.0</alfresco.min.version>
       <alfresco.max.version>6.99.99</alfresco.max.version>
       <alfresco.google.config.version>1.0.0</alfresco.google.config.version>
-      <alfresco.google.config.classifier>community</alfresco.google.config.classifier>
+      <alfresco.google.config.classifier>-community</alfresco.google.config.classifier>
       <compiler-plugin.version>3.1</compiler-plugin.version>
       <java.version>1.8</java.version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
   - update finalName with custom classifier
   - remove alfresco-maven-plugin -> was configured to add 6.0 classifier at the end of the finalName
   - set blank classifier for enterprise and '-community' for community amps