### PR TITLE
GOOGLEDOCS-463 : Release GoogleDocs 3.2.0-A1 (for 6.3.0-dev & next ACS Community release) [trigger release]

### DIFF
--- a/alfresco-googledrive-repo-base/pom.xml
+++ b/alfresco-googledrive-repo-base/pom.xml
@@ -16,24 +16,12 @@
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-repository</artifactId>
             <version>${dependency.alfresco-repository.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
             <artifactId>alfresco-data-model</artifactId>
             <version>${dependency.alfresco-data-model.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
-                </exclusion>
-            </exclusions>
             <scope>provided</scope>
         </dependency>
 
@@ -45,10 +33,6 @@
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava-jdk5</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-core</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.google.code.findbugs</groupId>
@@ -64,7 +48,11 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,8 @@
 
         <buildnumber>local</buildnumber>
 
-        <dependency.alfresco-repository.version>8.53</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.74</dependency.alfresco-data-model.version>
+        <dependency.alfresco-repository.version>8.83</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.84</dependency.alfresco-data-model.version>
         <dependency.share.version>6.2.0</dependency.share.version>
 
         <org.springframework.social-google-version>1.0.0.RELEASE
@@ -38,6 +38,23 @@
         <app.amp.folder>src/main/amp</app.amp.folder>
         <app.amp.output.folder>../${project.build.finalName}</app.amp.output.folder>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>4.5.10</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <scope>provided</scope>
+                <version>2.10.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <pluginManagement>


### PR DESCRIPTION
   - declare httpclient and jackson-core as provided in `dependencyManagement` so no other versions for these dependencies will be added to the amp