### PR TITLE
GOOGLEDOCS-477: Unable to check-in documents (on 2nd check-in)

### DIFF
--- a/googledrive-repository/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
+++ b/googledrive-repository/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
@@ -2042,7 +2042,8 @@ public class GoogleDocsServiceImpl
 
                             // if there is no author -- the entry is the initial
                             // creation
-                            if (revision.getLastModifyingUser().getEmailAddress() != null)
+                            if (revision.getLastModifyingUser() != null &&
+                                revision.getLastModifyingUser().getEmailAddress() != null)
                             {
                                 if (revision.getLastModifyingUser().getEmailAddress().equals(emailAddress))
                                 {
@@ -2072,7 +2073,8 @@ public class GoogleDocsServiceImpl
 
                     // if the authors list is empty -- the author was the original
                     // creator and it is the initial copy
-                    if (revisions.get(0).getLastModifyingUser().getEmailAddress() != null)
+                    if (revisions.get(0).getLastModifyingUser() != null &&
+                        revisions.get(0).getLastModifyingUser().getEmailAddress() != null)
                     {
 
                         if (!revisions.get(0).getLastModifyingUser().getEmailAddress().equals(emailAddress))


### PR DESCRIPTION
- add null checks on revision.getLastModifyingUser() calls