### PR TITLE
GOOGLEDOCS-477: Unable to check-in documents (on 2nd check-in)

### DIFF
--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
@@ -1839,7 +1839,8 @@ public class GoogleDocsServiceImpl implements GoogleDocsService
 
                         // if there is no author -- the entry is the initial
                         // creation
-                        if (revision.getLastModifyingUser().getEmailAddress() != null)
+                        if (revision.getLastModifyingUser() != null &&
+                            revision.getLastModifyingUser().getEmailAddress() != null)
                         {
                             if (revision.getLastModifyingUser().getEmailAddress().equals(
                                 emailAddress))
@@ -1868,7 +1869,8 @@ public class GoogleDocsServiceImpl implements GoogleDocsService
 
                 // if the authors list is empty -- the author was the original
                 // creator and it is the initial copy
-                if (revisions.get(0).getLastModifyingUser().getEmailAddress() != null)
+                if (revisions.get(0).getLastModifyingUser() != null &&
+                    revisions.get(0).getLastModifyingUser().getEmailAddress() != null)
                 {
 
                     if (!revisions.get(0).getLastModifyingUser().getEmailAddress().equals(


### PR DESCRIPTION
- add null checks on revision.getLastModifyingUser() calls