### PR TITLE
GOOGLEDOCS-481: Fix edit mode when using V3 Drive API on master (~ 3.2.0-Ax)

### DIFF
--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/GoogleDocsConstants.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/GoogleDocsConstants.java
@@ -58,10 +58,11 @@ public interface GoogleDocsConstants
     String SPREADSHEET_TYPE  = "spreadsheet";
 
     // Google Docs Mimetypes
-    String DOCUMENT_MIMETYPE     = "application/vnd.google-apps.document";
-    String SPREADSHEET_MIMETYPE  = "application/vnd.google-apps.spreadsheet";
-    String PRESENTATION_MIMETYPE = "application/vnd.google-apps.presentation";
-    String FOLDER_MIMETYPE       = "application/vnd.google-apps.folder";
+    String GDOCS_MIMETYPE_PREFIX = "application/vnd.google-apps.";
+    String DOCUMENT_MIMETYPE     = GDOCS_MIMETYPE_PREFIX+"document";
+    String SPREADSHEET_MIMETYPE  = GDOCS_MIMETYPE_PREFIX+"spreadsheet";
+    String PRESENTATION_MIMETYPE = GDOCS_MIMETYPE_PREFIX+"presentation";
+    String FOLDER_MIMETYPE       = GDOCS_MIMETYPE_PREFIX+"folder";
 
     // Google mimetypes
     String MIMETYPE_DOCUMENT     = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsService.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsService.java
@@ -453,6 +453,7 @@ public interface GoogleDocsService
 
     Serializable buildPermissionsPropertyValue(List<GooglePermission> permissions);
 
+    @Auditable(parameters = {"nodeRef", "url"})
     String convertWebViewToEditUrl(NodeRef nodeRef, String url);
 
     /**

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsService.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsService.java
@@ -453,6 +453,8 @@ public interface GoogleDocsService
 
     Serializable buildPermissionsPropertyValue(List<GooglePermission> permissions);
 
+    String convertWebViewToEditUrl(NodeRef nodeRef, String url);
+
     /**
      * Represents a named authority and their role on a Google Docs object. This should be compatible across the document list and
      * the drive APIs.

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
@@ -35,6 +35,7 @@ import static org.alfresco.integrations.google.docs.GoogleDocsConstants.CLIENT_S
 import static org.alfresco.integrations.google.docs.GoogleDocsConstants.CLIENT_SECRET_WEB;
 import static org.alfresco.integrations.google.docs.GoogleDocsConstants.DOCUMENT_MIMETYPE;
 import static org.alfresco.integrations.google.docs.GoogleDocsConstants.FOLDER_MIMETYPE;
+import static org.alfresco.integrations.google.docs.GoogleDocsConstants.GDOCS_MIMETYPE_PREFIX;
 import static org.alfresco.integrations.google.docs.GoogleDocsConstants.GOOGLE_ERROR_UNMUTABLE;
 import static org.alfresco.integrations.google.docs.GoogleDocsConstants.MIMETYPE_DOCUMENT;
 import static org.alfresco.integrations.google.docs.GoogleDocsConstants.MIMETYPE_PRESENTATION;
@@ -1053,7 +1054,7 @@ public class GoogleDocsServiceImpl implements GoogleDocsService
 
     private static boolean isGoogleDriveMimeType(final String mimeType)
     {
-        return mimeType != null && mimeType.startsWith("application/vnd.google-apps.");
+        return mimeType != null && mimeType.startsWith(GDOCS_MIMETYPE_PREFIX);
     }
 
     public void getSpreadSheet(Credential credential, NodeRef nodeRef, boolean removeFromDrive)
@@ -1169,6 +1170,19 @@ public class GoogleDocsServiceImpl implements GoogleDocsService
             // Get the mimetype
             FileInfo fileInfo = fileFolderService.getFileInfo(nodeRef);
             String mimetype = fileInfo.getContentData().getMimetype();
+
+            //
+            // https://developers.google.com/drive/api/v2/v3versusv2
+            //
+            //    To import Google Docs formats, you set the appropriate target mimeType in the resource body.
+            //    In v2, you set ?convert=true.
+            //
+            String gdocsType = getImportType(mimetype);
+            if (gdocsType != null)
+            {
+                // note: gdocsType = document, spreadsheet or presentation
+                mimetype = GDOCS_MIMETYPE_PREFIX+gdocsType;
+            }
 
             // Create the working Directory
             File workingDir = createWorkingDirectory(credential, nodeRef);

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
@@ -1478,7 +1478,7 @@ public class GoogleDocsServiceImpl implements GoogleDocsService
     // Convert web view (preview) url to an edit url
     //
     // For example from:
-    //      https://drive.google.com/a/alfresco.com/file/d/1ARe2I4tC2k33PXItOJWKfVEQaetf_F91/view?usp=drivesdk
+    //      https://drive.google.com/a/alfresco.com/file/d/1flbjW8a9fI56dPUsgb6_CoiAyNJxliHmVrAuK7KnRM4/view?usp=drivesdk
     // to:
     //      https://docs.google.com/spreadsheets/d/1flbjW8a9fI56dPUsgb6_CoiAyNJxliHmVrAuK7KnRM4/edit
     //

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/webscripts/CreateContent.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/webscripts/CreateContent.java
@@ -166,7 +166,7 @@ public class CreateContent extends GoogleDocsWebScripts
         googledocsService.lockNode(newNode);
 
         model.put(MODEL_NODEREF, newNode.toString());
-        model.put(MODEL_EDITOR_URL, file.getWebViewLink());
+        model.put(MODEL_EDITOR_URL, googledocsService.convertWebViewToEditUrl(newNode, file.getWebViewLink()));
 
         return model;
     }

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/webscripts/UploadContent.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/webscripts/UploadContent.java
@@ -229,7 +229,7 @@ public class UploadContent extends GoogleDocsWebScripts
         }
 
         model.put(MODEL_NODEREF, nodeRef.toString());
-        model.put(MODEL_EDITOR_URL, file.getWebViewLink());
+        model.put(MODEL_EDITOR_URL, googledocsService.convertWebViewToEditUrl(nodeRef, file.getWebViewLink()));
         return model;
     }
 

--- a/alfresco-googledrive-repo-community/src/main/amp/config/alfresco/subsystems/googledocs/drive/googledocs-context.xml
+++ b/alfresco-googledrive-repo-community/src/main/amp/config/alfresco/subsystems/googledocs/drive/googledocs-context.xml
@@ -66,6 +66,7 @@
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.getGooglePermissions=ACL_ALLOW
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.addRemotePermissions=ACL_ALLOW
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.isSiteManager=ACL_ALLOW
+                org.alfresco.integrations.google.docs.service.GoogleDocsService.convertWebViewToEditUrl=ACL_ALLOW
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.*=ACL_DENY
             </value>
         </property>

--- a/alfresco-googledrive-repo-enterprise/src/main/amp/config/alfresco/subsystems/googledocs/drive/googledocs-context.xml
+++ b/alfresco-googledrive-repo-enterprise/src/main/amp/config/alfresco/subsystems/googledocs/drive/googledocs-context.xml
@@ -66,6 +66,7 @@
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.getGooglePermissions=ACL_ALLOW
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.addRemotePermissions=ACL_ALLOW
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.isSiteManager=ACL_ALLOW
+                org.alfresco.integrations.google.docs.service.GoogleDocsService.convertWebViewToEditUrl=ACL_ALLOW
                 org.alfresco.integrations.google.docs.service.GoogleDocsService.*=ACL_DENY
             </value>
         </property>


### PR DESCRIPTION
On GDocs master (~ 3.2.0-Ax) when editing existing doc it seems to open in preview mode rather than edit mode

- example fix to convert V3 getWebViewLink to be an edit url (similar to V2 getAlternateLink)
- fix subsequent checkout (Edit In GoogleDocs) to upload as native GDoc mimetype (similar to V2 convert)