### PR TITLE
GOOGLEDOCS-489: Update 3.2.0-Ax to remove duplicate compile-time dependencies

### DIFF
--- a/alfresco-googledrive-repo-base/pom.xml
+++ b/alfresco-googledrive-repo-base/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-oauth2</artifactId>
-            <version>v2-rev20190313-1.30.1</version>
+            <version>v2-rev20200213-1.30.9</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20191108-1.30.3</version>
+            <version>v3-rev20200306-1.30.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>4.4.13</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <scope>provided</scope>
@@ -58,6 +64,18 @@
                 <artifactId>commons-codec</artifactId>
                 <scope>provided</scope>
                 <version>1.14</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <scope>provided</scope>
+                <version>28.2-jre</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.j2objc</groupId>
+                <artifactId>j2objc-annotations</artifactId>
+                <scope>provided</scope>
+                <version>1.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
- update to GDrive API "... 1.30.9"
- this will also resolve DependABot PRs:
  - https://github.com/Alfresco/googledrive/pull/136
  - https://github.com/Alfresco/googledrive/pull/117
- Repo provided libs include: gauva (& related) & httpcore