### PR TITLE
GOOGLEDOCS-476: Update GDocs 3.2.0-Ax to ACS 6.2.1-Ax dependencies (S…

### DIFF
--- a/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alfresco/alfresco-content-repository:6.2.0
+FROM alfresco/alfresco-content-repository:6.2.1-A1
 
 ARG IMAGEUSERNAME=alfresco
 ARG TOMCAT_DIR=/usr/local/tomcat
@@ -16,7 +16,7 @@ RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt-*.jar uninstall \
 # Copy Dockerfile to avoid an error if no AMPs exist
 COPY maven/target/*.amp $TOMCAT_DIR/amps/
 RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt*.jar install \
-              $TOMCAT_DIR/amps $TOMCAT_DIR/webapps/alfresco -directory -nobackup
+              $TOMCAT_DIR/amps/alfresco-google*-repo*.amp $TOMCAT_DIR/webapps/alfresco -nobackup
 
 
 USER ${IMAGEUSERNAME}

--- a/alfresco-googledrive-share/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-share/src/main/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM alfresco/alfresco-share:6.2.0
+# TODO remove quay.io/ after share 6.2.1 image published to hub.docker.com/r/alfresco/alfresco-share
+FROM quay.io/alfresco/alfresco-share:6.2.1-A4
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 
@@ -12,5 +13,5 @@ RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt-*.jar uninstall \
 # Copy Dockerfile to avoid an error if no AMPs exist
 COPY maven/target/*.amp $TOMCAT_DIR/amps_share/
 RUN java -jar $TOMCAT_DIR/alfresco-mmt/alfresco-mmt*.jar install \
-              $TOMCAT_DIR/amps_share $TOMCAT_DIR/webapps/share -directory -nobackup
+              $TOMCAT_DIR/amps_share/alfresco-google*-share*.amp $TOMCAT_DIR/webapps/share -nobackup
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -64,7 +64,7 @@ services:
         "
 
   transform-router:
-    image: quay.io/alfresco/alfresco-transform-router:1.1.0
+    image: quay.io/alfresco/alfresco-transform-router:1.1.1
     environment:
       JAVA_OPTS: " -Xms256m -Xmx512m"
       FILE_STORE_URL: "http://shared-file-store:8099/alfresco/api/-default-/private/sfs/versions/1/file"
@@ -78,7 +78,7 @@ services:
       - activemq
 
   alfresco-pdf-renderer:
-    image: quay.io/alfresco/alfresco-pdf-renderer:2.1.0
+    image: quay.io/alfresco/alfresco-pdf-renderer:2.1.1
     environment:
       JAVA_OPTS: " -Xms256m -Xmx512m"
       ACTIVEMQ_URL: "nio://activemq:61616"
@@ -89,7 +89,7 @@ services:
       - activemq
 
   imagemagick:
-    image: quay.io/alfresco/alfresco-imagemagick:2.1.0
+    image: quay.io/alfresco/alfresco-imagemagick:2.1.1
     environment:
       JAVA_OPTS: " -Xms256m -Xmx512m"
       ACTIVEMQ_URL: "nio://activemq:61616"
@@ -100,7 +100,7 @@ services:
       - activemq
 
   libreoffice:
-    image: quay.io/alfresco/alfresco-libreoffice:2.1.0
+    image: quay.io/alfresco/alfresco-libreoffice:2.1.1
     environment:
       JAVA_OPTS: " -Xms256m -Xmx512m"
       ACTIVEMQ_URL: "nio://activemq:61616"
@@ -111,7 +111,7 @@ services:
       - activemq
 
   tika:
-    image: quay.io/alfresco/alfresco-tika:2.1.0
+    image: quay.io/alfresco/alfresco-tika:2.1.1
     environment:
       JAVA_OPTS: " -Xms256m -Xmx512m"
       ACTIVEMQ_URL: "nio://activemq:61616"
@@ -122,7 +122,7 @@ services:
       - activemq
 
   misc:
-    image: quay.io/alfresco/alfresco-transform-misc:2.1.0
+    image: quay.io/alfresco/alfresco-transform-misc:2.1.1
     environment:
       JAVA_OPTS: " -Xms256m -Xmx768m"
       ACTIVEMQ_URL: "nio://activemq:61616"
@@ -133,7 +133,7 @@ services:
       - activemq
 
   shared-file-store:
-    image: alfresco/alfresco-shared-file-store:0.5.3
+    image: alfresco/alfresco-shared-file-store:0.6.0
     environment:
       JAVA_OPTS: " -Xms256m -Xmx512m"
       scheduler.content.age.millis: 86400000
@@ -156,7 +156,7 @@ services:
       - db-volume:/var/lib/postgresql/data
 
   solr6:
-    image: alfresco/alfresco-search-services:1.3.0.1
+    image: alfresco/alfresco-search-services:1.4.0
     environment:
       # Solr needs to know how to register itself with Alfresco
       SOLR_ALFRESCO_HOST: alfresco
@@ -182,7 +182,7 @@ services:
       - 61613:61613  # STOMP
 
   digital-workspace:
-    image: quay.io/alfresco/alfresco-digital-workspace:1.2.0
+    image: quay.io/alfresco/alfresco-digital-workspace:1.4.0
 
   proxy:
     image: quay.io/alfresco/alfresco-acs-nginx:3.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,13 @@
 
         <buildnumber>local</buildnumber>
 
-        <dependency.alfresco-repository.version>8.83</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.84</dependency.alfresco-data-model.version>
-        <dependency.share.version>6.2.0</dependency.share.version>
+        <dependency.alfresco-repository.version>7.154</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.50.5</dependency.alfresco-data-model.version>
+        <dependency.share.version>6.2.1-A4</dependency.share.version>
 
         <org.springframework.social-google-version>1.0.0.RELEASE
         </org.springframework.social-google-version>
-        <alfresco.min.version>6.0.0</alfresco.min.version>
+        <alfresco.min.version>6.2.0</alfresco.min.version>
         <alfresco.max.version>6.99.99</alfresco.max.version>
 
         <alfresco.google.config.version>1.0.0</alfresco.google.config.version>
@@ -44,7 +44,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.12</version>
+                <version>4.5.11</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
…hare/Repo)

- align with ACS 6.2.N (~ 6.2.1) including provided libs & references (eg. local docker image variants)
-- Repo 6.2.1-A1 (https://github.com/Alfresco/acs-packaging/tag/acs-packaging-6.2.1-A1)
-- Share 6.2.1-A4 (https://github.com/Alfresco/share/releases/tag/alfresco-share-parent-6.2.1-A4)
- update local docker-compose to align with ACS Deployment 3.N (~ 6.2.N)
-- minor: also bumped SFS to 0.6.0 (as per private ATS & AI deployments)