### PR TITLE
GOOGLEDOCS-490: Prep - align dependencies (and provided libs) to ACS 6.2.1-A2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,11 @@
 
         <buildnumber>local</buildnumber>
 
-        <dependency.alfresco-repository.version>7.154</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.50.5</dependency.alfresco-data-model.version>
+        <!--note: x-check against equivalent ACS tagged versions of pom.xml in acs-packaging, alfresco-repository, share ... -->
+
+        <dependency.alfresco-repository.version>7.164</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.50.9</dependency.alfresco-data-model.version>
+
         <dependency.share.version>6.2.1-A4</dependency.share.version>
 
         <org.springframework.social-google-version>1.0.0.RELEASE


### PR DESCRIPTION
- https://github.com/Alfresco/acs-packaging/blob/acs-packaging-6.2.1-A2/pom.xml