### PR TITLE
Googledocs 502 libs bumps to solve the security problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,10 @@ jobs:
       before_install: bash _ci/init.sh
       script: bash _ci/build.sh
 
-    - name: "WhiteSource"
-      stage: build
-      if: branch != company_release
+    - name: "Source Clear Scan (SCA)"  
       before_install: bash _ci/init.sh
-      script: bash _ci/whitesource.sh
+      # Run Veracode
+      script: travis_wait 30 bash _ci/source_clear.sh
 
     - name: "End-to-End Tests"
       stage: tests

--- a/_ci/source_clear.sh
+++ b/_ci/source_clear.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+echo "=========================== Starting SourceClear Script ==========================="
+PS4="\[\e[35m\]+ \[\e[m\]"
+set +e -v -x
+pushd "$(dirname "${BASH_SOURCE[0]}")/../"
+
+mvn -B -q clean install \
+    -DskipTests \
+    -Dmaven.javadoc.skip=true \
+    com.srcclr:srcclr-maven-plugin:scan \
+    -Dcom.srcclr.apiToken=${SRCCLR_API_TOKEN} > scan.log
+
+SUCCESS=$?   # this will read exit code of the previous command
+
+cat scan.log | grep -e 'Full Report Details' -e 'Failed'
+
+popd
+set +vex
+echo "=========================== Finishing SourceClear Script =========================="
+
+exit ${SUCCESS}

--- a/alfresco-googledrive-end-to-end-tests/pom.xml
+++ b/alfresco-googledrive-end-to-end-tests/pom.xml
@@ -93,7 +93,7 @@
                                 </image>
                                 <image>
                                     <alias>postgres</alias>
-                                    <name>postgres:10.1</name>
+                                    <name>postgres:11.7</name>
                                     <run>
                                         <hostname>postgres</hostname>
                                         <network>

--- a/alfresco-googledrive-repo-base/pom.xml
+++ b/alfresco-googledrive-repo-base/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-oauth2</artifactId>
-            <version>v2-rev20200213-1.30.9</version>
+            <version>v2-rev20200213-1.30.10</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>com.google.apis</groupId>
             <artifactId>google-api-services-drive</artifactId>
-            <version>v3-rev20200326-1.30.9</version>
+            <version>v3-rev20200618-1.30.10</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/service/GoogleDocsServiceImpl.java
@@ -163,6 +163,7 @@ import com.google.api.services.drive.model.Revision;
 import com.google.api.services.drive.model.RevisionList;
 import com.google.api.services.drive.model.User;
 import com.google.api.services.oauth2.Oauth2;
+import com.google.api.services.oauth2.model.Userinfo;
 import com.google.api.services.oauth2.model.Userinfoplus;
 
 /**
@@ -563,7 +564,7 @@ public class GoogleDocsServiceImpl implements GoogleDocsService
         final Oauth2 userInfoService = new Oauth2.Builder(new NetHttpTransport(),
             new JacksonFactory(),
             credential).setApplicationName(APPLICATION_NAME).build();
-        final Userinfoplus userInfo;
+        final Userinfo userInfo;
         try
         {
             userInfo = userInfoService

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       - shared-file-store-volume:/tmp/Alfresco/sfs
 
   postgres:
-    image: postgres:11.4
+    image: postgres:11.7
     environment:
       POSTGRES_PASSWORD: alfresco
       POSTGRES_USER: alfresco

--- a/pom.xml
+++ b/pom.xml
@@ -25,10 +25,10 @@
 
         <!--note: x-check against equivalent ACS tagged versions of pom.xml in acs-packaging, alfresco-repository, share ... -->
 
-        <dependency.alfresco-repository.version>7.171</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>8.50.11</dependency.alfresco-data-model.version>
+        <dependency.alfresco-repository.version>8.367</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>8.367</dependency.alfresco-data-model.version>
 
-        <dependency.share.version>6.2.1-RC1</dependency.share.version>
+        <dependency.share.version>7.0.0-M3</dependency.share.version>
 
         <org.springframework.social-google-version>1.0.0.RELEASE
         </org.springframework.social-google-version>
@@ -49,7 +49,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>4.5.11</version>
+                <version>4.5.13</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
@@ -62,13 +62,13 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-core</artifactId>
                 <scope>provided</scope>
-                <version>2.10.2</version>
+                <version>2.11.3</version>
             </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>
                 <scope>provided</scope>
-                <version>1.14</version>
+                <version>1.15</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
This PR resolve:
GDOCS-502 where the google apis got updated in order to resolve the transitive dependency on ouath-client libs
Remove of Whitesource
Introduce of SourceClear
Bumps on some libs for compile and test purpose