### PR TITLE
Make gson a provided dependency

### DIFF
--- a/alfresco-googledrive-repo-base/pom.xml
+++ b/alfresco-googledrive-repo-base/pom.xml
@@ -42,10 +42,6 @@
                     <groupId>com.google.code.gson</groupId>
                     <artifactId>gson</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>com.google.oauth-client</groupId>
-                    <artifactId>google-oauth-client</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -67,11 +63,6 @@
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>
             <version>1.42.2</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.oauth-client</groupId>
-            <artifactId>google-oauth-client</artifactId>
-            <version>1.33.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
                 <scope>provided</scope>
                 <version>1.3</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.oauth-client</groupId>
+                <artifactId>google-oauth-client</artifactId>
+                <version>1.33.3</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
The goal of this PR is to make gson a `provided` dependency. The AMP should not contain it because it's provided by the repo. What's more, in case of conflicts we have a failing as-packaging build like we have right now https://app.travis-ci.com/github/Alfresco/acs-packaging/jobs/587691371

If PR is accepted and merged then a new version should be released and integrated in the acs projects. The confirmation for the fix would be a green acs-packaging build.