### PR TITLE
Fix: Missing "Edit in Google Docs" Option and Improve Action Visibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,12 @@ jobs:
         stage: [ build , source_clear, e2e_tests ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17
@@ -59,7 +59,7 @@ jobs:
           cp -v _ci/settings.xml ${HOME}/.m2/
 
       - name: Cache the Maven packages to speed up build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -104,13 +104,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: Run
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@4
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_GITHUB_TOKEN }}
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17
@@ -118,7 +118,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Cache the Maven packages to speed up build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -160,12 +160,12 @@ jobs:
     if: github.ref_name == 'company_release'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set up Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: adopt
           java-version: 17
@@ -173,7 +173,7 @@ jobs:
           server-password: MAVEN_PASSWORD
 
       - name: Cache the Maven packages to speed up build
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/webscripts/DiscardContent.java
+++ b/alfresco-googledrive-repo-base/src/main/java/org/alfresco/integrations/google/docs/webscripts/DiscardContent.java
@@ -52,6 +52,7 @@ import org.alfresco.repo.transaction.TransactionListenerAdapter;
 import org.alfresco.service.cmr.repository.InvalidNodeRefException;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
+import org.alfresco.service.cmr.security.AuthorityService;
 import org.alfresco.service.cmr.site.SiteInfo;
 import org.alfresco.service.cmr.site.SiteService;
 import org.alfresco.service.transaction.TransactionService;
@@ -79,10 +80,17 @@ public class DiscardContent extends GoogleDocsWebScripts
     private SiteService        siteService;
     private FileNameUtil       fileNameUtil;
 
+    private AuthorityService authorityService;
+
     private static final String JSON_KEY_NODEREF  = "nodeRef";
     private static final String JSON_KEY_OVERRIDE = "override";
 
     private static final String MODEL_SUCCESS = "success";
+
+    public void setAuthorityService(AuthorityService authorityService)
+    {
+        this.authorityService = authorityService;
+    }
 
     public void setGoogledocsService(GoogleDocsService googledocsService)
     {
@@ -167,7 +175,7 @@ public class DiscardContent extends GoogleDocsWebScripts
                 deleted = delete(credential, nodeRef);
             }
             else if (googledocsService.isSiteManager(nodeRef,
-                AuthenticationUtil.getFullyAuthenticatedUser()))
+                AuthenticationUtil.getFullyAuthenticatedUser()) || authorityService.hasAdminAuthority())
             {
                 final String lockOwner = googledocsService.getGoogleDocsLockOwner(nodeRef);
 

--- a/alfresco-googledrive-repo-community/src/main/amp/config/alfresco/module/org.alfresco.integrations.google.docs/module-context.xml
+++ b/alfresco-googledrive-repo-community/src/main/amp/config/alfresco/module/org.alfresco.integrations.google.docs/module-context.xml
@@ -91,6 +91,7 @@
         <property name="transactionService" ref="transactionService"/>
         <property name="siteService" ref="SiteService"/>
         <property name="fileNameUtil" ref="fileNameUtil"/>
+        <property name="authorityService" ref="authorityService"/>
     </bean>
 
     <bean id="webscript.org.alfresco.integrations.google.docs.UserProfile.get"

--- a/alfresco-googledrive-repo-enterprise/src/main/amp/config/alfresco/module/org.alfresco.integrations.google.docs/module-context.xml
+++ b/alfresco-googledrive-repo-enterprise/src/main/amp/config/alfresco/module/org.alfresco.integrations.google.docs/module-context.xml
@@ -91,6 +91,7 @@
         <property name="transactionService" ref="transactionService"/>
         <property name="siteService" ref="SiteService"/>
         <property name="fileNameUtil" ref="fileNameUtil"/>
+        <property name="authorityService" ref="authorityService"/>
     </bean>
 
     <bean id="webscript.org.alfresco.integrations.google.docs.UserProfile.get"

--- a/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/alfresco/alfresco-content-repository:23.2.0-A21
+FROM quay.io/alfresco/alfresco-content-repository:25.2.0-A.5
 
 ARG IMAGEUSERNAME=alfresco
 ARG TOMCAT_DIR=/usr/local/tomcat

--- a/alfresco-googledrive-share/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-share/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 # TODO remove quay.io/ after share 6.2.1 image published to hub.docker.com/r/alfresco/alfresco-share
-FROM quay.io/alfresco/alfresco-share:23.2.0-A21
+FROM quay.io/alfresco/alfresco-share:25.2.0-A.5
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 

--- a/alfresco-googledrive-share/src/main/documentLibrary-config/withManagerCancel/custom-slingshot-googledocs-context.xml
+++ b/alfresco-googledrive-share/src/main/documentLibrary-config/withManagerCancel/custom-slingshot-googledocs-context.xml
@@ -93,14 +93,31 @@
       </property>
    </bean>
 
-    <bean id="evaluator.doclib.google.docs.cancel.manager" parent="evaluator.doclib.action.chainedMatchAll">
-        <property name="evaluators">
-            <list>
-                <ref bean="evaluator.doclib.google.docs.aspect" />
-                <ref bean="evaluator.doclib.action.isSiteManager" />
-            </list>
-        </property>
-    </bean>
+   <bean id="evaluator.doclib.google.docs.cancel.manager" parent="evaluator.doclib.action.chainedMatchAll">
+      <property name="evaluators">
+         <list>
+            <ref bean="evaluator.doclib.google.docs.aspect" />
+            <ref bean="evaluator.doclib.google.docs.cancel.managerOrAdmin" />
+         </list>
+      </property>
+   </bean>
+
+   <bean id="evaluator.doclib.google.docs.cancel.managerOrAdmin" parent="evaluator.doclib.action.chainedMatchOne">
+      <property name="evaluators">
+         <list>
+            <ref bean="evaluator.doclib.action.isSiteManager" />
+            <ref bean="evaluator.doclib.google.docs.isAdmin" />
+         </list>
+      </property>
+   </bean>
+   <bean id="evaluator.doclib.google.docs.isAdmin" parent="evaluator.doclib.action.groupMembership">
+      <property name="groups">
+         <list>
+            <value>GROUP_ALFRESCO_ADMINISTRATORS</value>
+            <value>GROUP_ALFRESCO_SYSTEM_ADMINISTRATORS</value>
+         </list>
+      </property>
+   </bean>
 
     <bean id="evaluator.doclib.google.docs.cancel" parent="evaluator.doclib.action.chainedMatchOne">
         <property name="evaluators">

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,10 @@
 
         <!--note: x-check against equivalent ACS tagged versions of pom.xml in acs-packaging, alfresco-repository, share ... -->
 
-        <dependency.alfresco-repository.version>23.2.0.56</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>23.2.0.56</dependency.alfresco-data-model.version>
+        <dependency.alfresco-repository.version>25.2.0.13</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>25.2.0.13</dependency.alfresco-data-model.version>
 
-        <dependency.share.version>23.2.0.63</dependency.share.version>
+        <dependency.share.version>25.2.0.14</dependency.share.version>
 
         <org.springframework.social-google-version>1.0.0.RELEASE
         </org.springframework.social-google-version>


### PR DESCRIPTION
This update resolves the issue where the "Edit in Google Docs" option was not visible as expected, ensuring it now appears appropriately. It also hides the "Unlock Document" action and implements proper handling for the previously missing "Cancel Editing in Google Docs" action.