### PR TITLE
[ACS-11988]: Release 4.1.1-A1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: adopt
-          java-version: 17
+          java-version: 21
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
@@ -118,7 +118,7 @@ jobs:
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: adopt
-          java-version: 17
+          java-version: 21
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 
@@ -176,7 +176,7 @@ jobs:
         uses: actions/setup-java@1bcf9fb12cf4aa7d266a90ae39939e61372fe520 # v5.4.0
         with:
           distribution: adopt
-          java-version: 17
+          java-version: 21
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
 

--- a/alfresco-googledrive-end-to-end-tests/pom.xml
+++ b/alfresco-googledrive-end-to-end-tests/pom.xml
@@ -89,6 +89,12 @@
                                         <ports>
                                             <port>4444:4444</port>
                                         </ports>
+                                        <!-- Give Chrome a large /dev/shm to avoid "tab crashed" failures. -->
+                                        <volumes>
+                                            <bind>
+                                                <volume>/dev/shm:/dev/shm</volume>
+                                            </bind>
+                                        </volumes>
                                     </run>
                                 </image>
                                 <image>

--- a/alfresco-googledrive-end-to-end-tests/pom.xml
+++ b/alfresco-googledrive-end-to-end-tests/pom.xml
@@ -1,14 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-googledrive-end-to-end-tests</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.1-A1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Alfresco / Google Drive E2E Tests</name>
 
     <parent>
         <artifactId>alfresco-googledrive</artifactId>
         <groupId>org.alfresco.integrations</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1-A1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/alfresco-googledrive-end-to-end-tests/src/test/java/org/alfresco/integrations/google/docs/GoogleDocsIT.java
+++ b/alfresco-googledrive-end-to-end-tests/src/test/java/org/alfresco/integrations/google/docs/GoogleDocsIT.java
@@ -45,7 +45,12 @@ public class GoogleDocsIT
     @Before
     public void setup() throws Exception
     {
-        driver = new RemoteWebDriver(new URL("http://localhost:4444/wd/hub"), new ChromeOptions());
+        ChromeOptions options = new ChromeOptions();
+        options.addArguments("--no-sandbox");
+        options.addArguments("--disable-dev-shm-usage");
+        options.addArguments("--disable-gpu");
+
+        driver = new RemoteWebDriver(new URL("http://localhost:4444/wd/hub"), options);
         wait = new WebDriverWait(driver, 30);
     }
 

--- a/alfresco-googledrive-repo-base/pom.xml
+++ b/alfresco-googledrive-repo-base/pom.xml
@@ -1,14 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-googledrive-repo-base</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.1-A1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Alfresco / Google Drive Repo Base Module</name>
 
     <parent>
         <groupId>org.alfresco.integrations</groupId>
         <artifactId>alfresco-googledrive</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1-A1-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/alfresco-googledrive-repo-community/pom.xml
+++ b/alfresco-googledrive-repo-community/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>alfresco-googledrive</artifactId>
         <groupId>org.alfresco.integrations</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1-A1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.alfresco.integrations</groupId>
             <artifactId>alfresco-googledrive-repo-base</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.1.1-A1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.alfresco.integrations</groupId>

--- a/alfresco-googledrive-repo-enterprise/pom.xml
+++ b/alfresco-googledrive-repo-enterprise/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>alfresco-googledrive</artifactId>
         <groupId>org.alfresco.integrations</groupId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1-A1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.alfresco.integrations</groupId>
             <artifactId>alfresco-googledrive-repo-base</artifactId>
-            <version>4.1.1-SNAPSHOT</version>
+            <version>4.1.1-A1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.alfresco.integrations</groupId>

--- a/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/alfresco/alfresco-content-repository:26.2.0.83
+FROM quay.io/alfresco/alfresco-content-repository:26.2.0-A.24
 
 ARG IMAGEUSERNAME=alfresco
 ARG TOMCAT_DIR=/usr/local/tomcat

--- a/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-repo-enterprise/src/main/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/alfresco/alfresco-content-repository:25.2.0-A.5
+FROM quay.io/alfresco/alfresco-content-repository:26.2.0.83
 
 ARG IMAGEUSERNAME=alfresco
 ARG TOMCAT_DIR=/usr/local/tomcat

--- a/alfresco-googledrive-share/pom.xml
+++ b/alfresco-googledrive-share/pom.xml
@@ -1,14 +1,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>alfresco-googledrive-share</artifactId>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.1-A1-SNAPSHOT</version>
     <packaging>amp</packaging>
     <name>Alfresco / Google Drive Share Module</name>
 
     <parent>
         <groupId>org.alfresco.integrations</groupId>
         <artifactId>alfresco-googledrive</artifactId>
-        <version>4.1.1-SNAPSHOT</version>
+        <version>4.1.1-A1-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/alfresco-googledrive-share/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-share/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 # TODO remove quay.io/ after share 6.2.1 image published to hub.docker.com/r/alfresco/alfresco-share
-FROM quay.io/alfresco/alfresco-share:26.2.0.53
+FROM quay.io/alfresco/alfresco-share:26.2.0-A.24
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 

--- a/alfresco-googledrive-share/src/main/docker/Dockerfile
+++ b/alfresco-googledrive-share/src/main/docker/Dockerfile
@@ -1,5 +1,5 @@
 # TODO remove quay.io/ after share 6.2.1 image published to hub.docker.com/r/alfresco/alfresco-share
-FROM quay.io/alfresco/alfresco-share:25.2.0-A.5
+FROM quay.io/alfresco/alfresco-share:26.2.0.53
 
 ARG TOMCAT_DIR=/usr/local/tomcat
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>21</java.version>
+        <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>org.alfresco.integrations</groupId>
     <artifactId>alfresco-googledrive</artifactId>
     <name>Alfresco / Google Drive Parent</name>
-    <version>4.1.1-SNAPSHOT</version>
+    <version>4.1.1-A1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,10 @@
 
         <!--note: x-check against equivalent ACS tagged versions of pom.xml in acs-packaging, alfresco-repository, share ... -->
 
-        <dependency.alfresco-repository.version>25.2.0.13</dependency.alfresco-repository.version>
-        <dependency.alfresco-data-model.version>25.2.0.13</dependency.alfresco-data-model.version>
+        <dependency.alfresco-repository.version>26.2.0.83</dependency.alfresco-repository.version>
+        <dependency.alfresco-data-model.version>26.2.0.83</dependency.alfresco-data-model.version>
 
-        <dependency.share.version>25.2.0.14</dependency.share.version>
+        <dependency.share.version>26.2.0.53</dependency.share.version>
 
         <org.springframework.social-google-version>1.0.0.RELEASE
         </org.springframework.social-google-version>


### PR DESCRIPTION
# This PR is mainly for alpha release 4.1.1-A.1.

## But we faced some failures in the CI, it was caused by "GoogleDocsIT.testShareLogin", 
```
org.openqa.selenium.WebDriverException: unknown error: session deleted because of page crash
from unknown error: cannot determine loading status
from tab crashed  (Session info: chrome=102.0.5005.61)

```

## Fix flaky E2E test: Chrome "tab crashed" in CI

GoogleDocsIT.testShareLogin was failing intermittently with session deleted because of page crash / tab crashed. This wasn't a test-logic issue — Chrome's renderer was crashing because Docker's default 64 MB /dev/shm limit isn't enough for real page loads.

Changes:

Browser level — added Chrome flags in GoogleDocsIT.setup():

```
--no-sandbox — Chrome sandbox can't init as root in a container

--disable-dev-shm-usage — redirects shared memory writes to /tmp instead of /dev/shm

--disable-gpu — no GPU available in CI, disables hardware acceleration
```

Infrastructure level — mounted host's ```/dev/shm``` into the Selenium container via pom.xml:



```
<volumes>
    <bind>
        <volume>/dev/shm:/dev/shm</volume>
    </bind>
</volumes>
```

Why both? --disable-dev-shm-usage is a browser-level workaround (redirects to disk), but can be slower and occasionally insufficient. The /dev/shm mount is the root-cause fix (Selenium's recommended approach), removing the 64 MB cap entirely. Together they provide defense in depth — the test stays stable regardless of which mechanism kicks in.